### PR TITLE
Issue 1,23

### DIFF
--- a/api/domain/build.gradle.kts
+++ b/api/domain/build.gradle.kts
@@ -4,8 +4,9 @@ plugins {
 
 allOpen {
     annotation("javax.transaction.Transactional")
+    annotation("org.springframework.transaction.annotation.Transactional")
 }
 
 dependencies {
-    implementation(group = "org.jboss.spec.javax.transaction", name = "jboss-transaction-api_1.2_spec", version = "2.0.0.CR1")
+    implementation("org.springframework:spring-tx:5.3.27")
 }

--- a/api/domain/src/main/kotlin/linkpool/link/folder/service/CreateFolderService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/folder/service/CreateFolderService.kt
@@ -7,7 +7,7 @@ import linkpool.link.folder.port.`in`.CreateFolderUseCase
 import linkpool.link.folder.port.`in`.SaveFolderRequest
 import linkpool.link.folder.port.out.FolderPort
 import java.time.LocalDateTime
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/link/folder/service/DeleteFolderService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/folder/service/DeleteFolderService.kt
@@ -4,7 +4,7 @@ import linkpool.common.DomainComponent
 import linkpool.exception.NotAuthorizedForDataException
 import linkpool.link.folder.port.`in`.DeleteFolderUseCase
 import linkpool.link.folder.port.out.FolderPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/link/folder/service/UpdateFolderService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/folder/service/UpdateFolderService.kt
@@ -5,7 +5,7 @@ import linkpool.exception.NotAuthorizedForDataException
 import linkpool.link.folder.port.`in`.UpdateFolderRequest
 import linkpool.link.folder.port.`in`.UpdateFolderUseCase
 import linkpool.link.folder.port.out.FolderPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/link/folder/service/WithdrawalFolderService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/folder/service/WithdrawalFolderService.kt
@@ -4,7 +4,7 @@ import linkpool.common.DomainComponent
 import linkpool.link.folder.port.`in`.WithdrawalFolderUseCase
 import linkpool.link.folder.port.out.FolderPort
 import linkpool.user.user.model.UserSignedOutEvent
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/link/folderlink/service/CreateFolderLinkBulkService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/folderlink/service/CreateFolderLinkBulkService.kt
@@ -7,7 +7,7 @@ import linkpool.link.folderlink.port.`in`.BulkCreateRequest
 import linkpool.link.folderlink.port.`in`.CreateFolderLinkBulkUseCase
 import linkpool.link.link.port.`in`.CreateLinkUseCase
 import linkpool.link.link.port.`in`.SaveLinkRequest
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/link/folderlink/service/DeleteFolderLinkService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/folderlink/service/DeleteFolderLinkService.kt
@@ -5,7 +5,7 @@ import linkpool.exception.NotAuthorizedForDataException
 import linkpool.link.folder.port.`in`.DeleteFolderUseCase
 import linkpool.link.folder.port.out.FolderPort
 import linkpool.link.folderlink.port.`in`.DeleteFolderLinkUseCase
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/link/link/service/CreateLinkService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/link/service/CreateLinkService.kt
@@ -7,7 +7,7 @@ import linkpool.link.link.port.`in`.CreateLinkUseCase
 import linkpool.link.link.port.`in`.SaveLinkRequest
 import linkpool.link.link.port.out.LinkPort
 import java.time.LocalDateTime
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/link/link/service/DeleteLinkService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/link/service/DeleteLinkService.kt
@@ -5,7 +5,7 @@ import linkpool.exception.DataNotFoundException
 import linkpool.exception.NotAuthorizedForDataException
 import linkpool.link.link.port.`in`.DeleteLinkUseCase
 import linkpool.link.link.port.out.LinkPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/link/link/service/GetLinksService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/link/service/GetLinksService.kt
@@ -6,7 +6,7 @@ import linkpool.common.DomainComponent
 import linkpool.link.link.model.Link
 import linkpool.link.link.port.`in`.GetLinksUseCase
 import linkpool.link.link.port.out.LinkPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/link/link/service/UpdateLinkService.kt
+++ b/api/domain/src/main/kotlin/linkpool/link/link/service/UpdateLinkService.kt
@@ -6,7 +6,7 @@ import linkpool.exception.NotAuthorizedForDataException
 import linkpool.link.link.port.`in`.UpdateLinkRequest
 import linkpool.link.link.port.`in`.UpdateLinkUseCase
 import linkpool.link.link.port.out.LinkPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/report/report/service/CreateReportService.kt
+++ b/api/domain/src/main/kotlin/linkpool/report/report/service/CreateReportService.kt
@@ -8,7 +8,7 @@ import linkpool.report.report.port.out.ReportPort
 import linkpool.report.report.model.Report
 import linkpool.report.report.model.ReportReason
 import linkpool.report.report.model.ReportTarget
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/report/report/service/GetReportService.kt
+++ b/api/domain/src/main/kotlin/linkpool/report/report/service/GetReportService.kt
@@ -5,7 +5,7 @@ import linkpool.report.report.model.Report
 import linkpool.report.report.model.ReportTarget
 import linkpool.report.report.port.`in`.GetReportUseCase
 import linkpool.report.report.port.out.ReportPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/user/jobgroup/service/JobGroupQueryService.kt
+++ b/api/domain/src/main/kotlin/linkpool/user/jobgroup/service/JobGroupQueryService.kt
@@ -5,7 +5,7 @@ import linkpool.exception.DataNotFoundException
 import linkpool.user.jobgroup.model.JobGroup
 import linkpool.user.jobgroup.port.`in`.JobGroupQuery
 import linkpool.user.jobgroup.port.out.JobGroupPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/user/user/model/User.kt
+++ b/api/domain/src/main/kotlin/linkpool/user/user/model/User.kt
@@ -14,9 +14,10 @@ class User(
     private var deleted: Boolean = false
 ) {
 
-    fun signOut() {
+    fun signOut(): UserSignedOutEvent {
         profile = null
         deleted = true
+        return UserSignedOutEvent(id)
     }
 
     fun activate() {

--- a/api/domain/src/main/kotlin/linkpool/user/user/service/CreateUserService.kt
+++ b/api/domain/src/main/kotlin/linkpool/user/user/service/CreateUserService.kt
@@ -6,7 +6,7 @@ import linkpool.user.user.port.`in`.CreateUserResponse
 import linkpool.user.user.port.`in`.CreateUserUseCase
 import linkpool.user.user.port.out.UserAuthPort
 import linkpool.user.user.port.out.UserPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/user/user/service/GetUserService.kt
+++ b/api/domain/src/main/kotlin/linkpool/user/user/service/GetUserService.kt
@@ -6,7 +6,7 @@ import linkpool.exception.NotSignedUpException
 import linkpool.user.user.model.User
 import linkpool.user.user.port.`in`.GetUserUseCase
 import linkpool.user.user.port.out.UserPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/domain/src/main/kotlin/linkpool/user/user/service/SignOutService.kt
+++ b/api/domain/src/main/kotlin/linkpool/user/user/service/SignOutService.kt
@@ -6,7 +6,6 @@ import linkpool.user.user.port.`in`.GetUserUseCase
 import linkpool.user.user.port.`in`.SignOutUseCase
 import linkpool.user.user.port.out.UserPort
 import linkpool.user.user.port.out.UserEventPublishPort
-import linkpool.user.user.model.UserSignedOutEvent
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.reactive.TransactionalOperator
 import org.springframework.transaction.reactive.executeAndAwait
@@ -23,10 +22,11 @@ class SignOutService(
     override suspend fun signOut(userId: Long) {
         transactionalOperator.executeAndAwait {
             val user = getUserUseCase.getById(userId)
-            user.signOut()
+            val event = user.signOut()
             userPort.patch(user)
-        }.run {
-            userEventPublishPort.publishUserSignedOutEvent(UserSignedOutEvent(userId))
+            event
+        }?.let {
+            userEventPublishPort.publishUserSignedOutEvent(it)
         }
     }
 }

--- a/api/domain/src/main/kotlin/linkpool/user/user/service/SignOutService.kt
+++ b/api/domain/src/main/kotlin/linkpool/user/user/service/SignOutService.kt
@@ -7,21 +7,26 @@ import linkpool.user.user.port.`in`.SignOutUseCase
 import linkpool.user.user.port.out.UserPort
 import linkpool.user.user.port.out.UserEventPublishPort
 import linkpool.user.user.model.UserSignedOutEvent
-
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.reactive.TransactionalOperator
+import org.springframework.transaction.reactive.executeAndAwait
 
 @DomainComponent
 @Transactional
 class SignOutService(
     private val getUserUseCase: GetUserUseCase,
     private val userPort: UserPort,
-    private val userEventPublishPort: UserEventPublishPort
+    private val userEventPublishPort: UserEventPublishPort,
+    private val transactionalOperator: TransactionalOperator
 ): SignOutUseCase {
 
     override suspend fun signOut(userId: Long) {
-        val user = getUserUseCase.getById(userId)
-        user.signOut()
-        userPort.patch(user)
-        userEventPublishPort.publishUserSignedOutEvent(UserSignedOutEvent(user.id))
+        transactionalOperator.executeAndAwait {
+            val user = getUserUseCase.getById(userId)
+            user.signOut()
+            userPort.patch(user)
+        }.run {
+            userEventPublishPort.publishUserSignedOutEvent(UserSignedOutEvent(userId))
+        }
     }
 }

--- a/api/domain/src/main/kotlin/linkpool/user/user/service/UpdateUserService.kt
+++ b/api/domain/src/main/kotlin/linkpool/user/user/service/UpdateUserService.kt
@@ -6,7 +6,7 @@ import linkpool.user.user.port.`in`.GetUserUseCase
 import linkpool.user.user.port.`in`.UpdateUserUseCase
 import linkpool.user.user.port.`in`.ProfileRequest
 import linkpool.user.user.port.out.UserPort
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @DomainComponent
 @Transactional

--- a/api/infra/src/main/kotlin/linkpool/event/UserSignedOutEventListener.kt
+++ b/api/infra/src/main/kotlin/linkpool/event/UserSignedOutEventListener.kt
@@ -28,9 +28,7 @@ class UserSignedOutEventListener(
 
     @ServiceActivator(inputChannel = "signedOutEvent")
     fun handleForSignedOutEventListener(@Payload message: Message<UserSignedOutEvent>) {
-        CoroutineScope(CoroutineExceptionHandler { _, exception ->
-            log.error("$exception in the handleForSignedOutEventListener")
-        } + Dispatchers.IO).launch {
+        CoroutineScope(Dispatchers.IO).launch {
             val folderEventDeferred = safeAsync {
                 folderEventListener.deleteBatchAll(message.payload)
             }

--- a/api/infra/src/main/kotlin/linkpool/event/UserSignedOutEventListener.kt
+++ b/api/infra/src/main/kotlin/linkpool/event/UserSignedOutEventListener.kt
@@ -40,10 +40,11 @@ class UserSignedOutEventListener(
 
             folderEventDeferred.await()
                 .onSuccess { log.info("succeed in folderEventListener from UserSignedOut... userId: ${message.payload.userId}") }
-                .onFailure { e -> log.info("Error in folderEventListener from UserSignedOut... userId: ${message.payload.userId} \n error: ${e.message}") }
+                .onFailure { e -> log.error("Error in folderEventListener from UserSignedOut... userId: ${message.payload.userId} \n error: ${e.message}") }
             linkEventDeferred.await()
                 .onSuccess { log.info("succeed in linkEventListener from UserSignedOut... userId: ${message.payload.userId}") }
-                .onFailure { e -> log.info("Error in linkEventListener from UserSignedOut... userId: ${message.payload.userId} \n error: ${e.message}") }
+                .onFailure { e -> log.error("Error in linkEventListener from UserSignedOut... userId: ${message.payload.userId} \n error: ${e.message}") }
+
         }
     }
 }

--- a/api/infra/src/main/kotlin/linkpool/event/UserSignedOutEventPublisher.kt
+++ b/api/infra/src/main/kotlin/linkpool/event/UserSignedOutEventPublisher.kt
@@ -3,15 +3,13 @@ package linkpool.event
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.springframework.beans.factory.annotation.Qualifier
 import linkpool.user.user.model.UserSignedOutEvent
 import linkpool.user.user.port.out.UserEventPublishPort
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.integration.config.EnablePublisher
 import org.springframework.messaging.MessageChannel
 import org.springframework.messaging.support.MessageBuilder
 import org.springframework.stereotype.Component
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
 
 
 @Component
@@ -21,7 +19,6 @@ class UserSignedOutEventPublisher(
     private val outputChannel: MessageChannel
 ) : UserEventPublishPort {
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     override fun publishUserSignedOutEvent(userSignedOutEvent: UserSignedOutEvent) {
         CoroutineScope(Dispatchers.IO).launch {
             val message = MessageBuilder.withPayload(userSignedOutEvent).build()

--- a/api/infra/src/main/kotlin/linkpool/event/UserSignedOutEventPublisher.kt
+++ b/api/infra/src/main/kotlin/linkpool/event/UserSignedOutEventPublisher.kt
@@ -2,6 +2,7 @@ package linkpool.event
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.springframework.beans.factory.annotation.Qualifier
 import linkpool.user.user.model.UserSignedOutEvent
 import linkpool.user.user.port.out.UserEventPublishPort
@@ -22,7 +23,7 @@ class UserSignedOutEventPublisher(
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     override fun publishUserSignedOutEvent(userSignedOutEvent: UserSignedOutEvent) {
-        CoroutineScope(Dispatchers.IO).run {
+        CoroutineScope(Dispatchers.IO).launch {
             val message = MessageBuilder.withPayload(userSignedOutEvent).build()
             outputChannel.send(message)
         }

--- a/api/infra/src/main/resources/application-local.properties
+++ b/api/infra/src/main/resources/application-local.properties
@@ -7,5 +7,6 @@ application.url=http://localhost:80
 
 #logging.level.io.r2dbc=DEBUG
 #logging.level.org.springframework.data.r2dbc=DEBUG
+#logging.level.org.springframework.transaction=TRACE
 
 logging.level.org.springframework.r2dbc.core=debug


### PR DESCRIPTION
# #1 #23 

## Type

- [x] New Feature
- [x] Refactor
- [ ] Bug Fix
- [ ] CI/CD
- [ ] Set Up
- [ ] Small Correction

## 개요
리액티브 트랜잭션을 제어하여 트랜잭션 커밋 이후에 Integration Publisher가 수행되도록 로직을 수정함.

## 작업 내용

- javax 트랜잭션에서 springframework 트랜잭션으로 변경
- transactionOperator을 이용한 트랜잭션 제어
- 메세지 컨슈밍부 로그레벨 변경
- 메세지 발행부 비동기  블럭으로 변경
